### PR TITLE
1.19

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[47,)"
+loaderVersion = "[43,)"
 #issueTrackerURL = ""
 license = "Insert License Here"
 


### PR DESCRIPTION
The was a issue with 1.19 where it wanted forge 47 but there is no Forge 47 for 1.19 so i changed it to 43 the latest version for 1.19
